### PR TITLE
Promote sln with Configuration parameter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,8 @@ mono:
   # http://download.mono-project.com/repo/debian/dists/wheezy/snapshots/
   - 5.2.0
 script:
-  - cd src/CVNBot
-  - xbuild CVNBot.csproj /p:Configuration=Release
-  - xbuild CVNBot.csproj /p:Configuration=Debug
+  - xbuild src/CVNBot.sln /p:Configuration=Release
+  - xbuild src/CVNBot.sln /p:Configuration=Debug
 notifications:
   irc:
     channels:

--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ Or, if using `apt-get`, use one of these:
 
 Currently supported versions of Mono: **4.6**, **5.4**
 
-Once mono is installed, build the project:
+Once mono is installed, build the project. The below uses Debug for local development. (See [Installation](https://github.com/countervandalism/CVNBot/wiki#installation) for how to install it properly, don't run from Debug in production!):
 
 ```bash
-countervandalism/CVNBot/src/CVNBot:$ xbuild CVNBot.csproj
+countervandalism/CVNBot/src/CVNBot:$ xbuild src/CVNBot.sln /p:Configuration=Debug
 ```
 
-Once built, you can run it (see [Installation](https://github.com/countervandalism/CVNBot/wiki/Documentation#installation) for more info on how to properly install it for actual usage, don't run it from the Debug directory in production):
+Once built, you can run it:
 ```bash
 countervandalism/CVNBot/src/CVNBot/bin/Debug:$ mono CVNBot.exe
 ```


### PR DESCRIPTION
We still use csproj internally, but let's promote the higher
entry point for the solution by default.

Also:

* Show how the Configuration parameter is passed, which
  developers will learn later otherwise.

* Update Travis to use the same.