### PR TITLE
Update copyright statement

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,10 @@
+# usage: git shortlog -se
+#
+# This file is sorted alphabetically.
+#
+MarcoAurelio <30000615+MarcoAurelioWM@users.noreply.github.com>
+rxy <github@rxy.jp>
+rxy <github@rxy.jp> <rxy+github@rxy.jp>
+rxy <github@rxy.jp> <rxy@rxy.jp>
+rxy <github@rxy.jp> <ryu@hosiryuhosi.jp>
+Timo Tijhof <krinklemail@gmail.com>

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,4 +1,0 @@
-Tangotango <tangotango.wp@gmail.com>
-Alex Zariv <alex@alexzariv.com>
-Mike Lifeguard <lifeguard@toolserver.org>
-Timo Tijhof <krinklemail@gmail.com>

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,8 @@
-Copyright (c) 2006-2017 Countervandalism Network and other contributors, 
-http://countervandalism.net/
+Copyright 2014-2018 rxy <github@rxy.jp>
+Copyright 2010-2018 Timo Tijhof <krinklemail@gmail.com>
+Copyright 2007-2018 Alex Zariv <alex@alexzariv.com>
+Copyright 2007-2010 Mike Lifeguard <lifeguard@toolserver.org>
+Copyright 2006-2009 Tangotango <tangotango.wp@gmail.com>
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation


### PR DESCRIPTION
Give the main contributors direct credit in the license for better
visibility (the AUTHORS.txt file is optional for distribution,
and wasn't maintainers very well, either).

Also add a mailmap file to normalise multiple names/addresses in
the commit history that relate to the same person, used by
the git-log and git-shortlog commands.

Also rename MIT-LICENSE.txt to LICENSE.txt for simplicity.