### PR TITLE
Updated command parsing regex

### DIFF
--- a/src/CVNBot/ListManager.cs
+++ b/src/CVNBot/ListManager.cs
@@ -27,7 +27,7 @@ namespace CVNBot
 
         static Regex ipv4 = new Regex(@"\b(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b");
         static Regex ipv6 = new Regex(@"\b(?:[0-9A-F]{1,4}:){7}[0-9A-F]{1,4}\b");
-        static Regex rlistCmd = new Regex(@"^(?<cmd>add|del|show|test) +(?<item>\S+?)(?: +p=(?<project>\S+?))?(?: +x=(?<len>\d{1,4}))?(?: +r=(?<reason>.+?))?$"
+        static Regex rlistCmd = new Regex(@"^(?<cmd>add|del|show|test) +(?<item>.+?)(?: +p=(?<project>\S+?))?(?: +x=(?<len>\d{1,4}))?(?: +r=(?<reason>.+?))?$"
             , RegexOptions.IgnoreCase);
 
         readonly Object dbtoken = new Object();

--- a/src/CVNBot/ListManager.cs
+++ b/src/CVNBot/ListManager.cs
@@ -27,7 +27,7 @@ namespace CVNBot
 
         static Regex ipv4 = new Regex(@"\b(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b");
         static Regex ipv6 = new Regex(@"\b(?:[0-9A-F]{1,4}:){7}[0-9A-F]{1,4}\b");
-        static Regex rlistCmd = new Regex(@"^(?<cmd>add|del|show|test) (?<item>.+?)(?: p=(?<project>\S+?))?(?: x=(?<len>\d{1,4}))?(?: r=(?<reason>.+?))?$"
+        static Regex rlistCmd = new Regex(@"^(?<cmd>add|del|show|test) +(?<item>\S+?)(?: +p=(?<project>\S+?))?(?: +x=(?<len>\d{1,4}))?(?: +r=(?<reason>.+?))?$"
             , RegexOptions.IgnoreCase);
 
         readonly Object dbtoken = new Object();


### PR DESCRIPTION
The updated regex fixes issue #44 
I've tested the updated regex myself and it was able to handle any command I threw at it. The functional differences in the expression are:
 - any amount of spaces (greater than 0, of course) is allowed between capturing groups
 - item match now only matches non-whitespace character (I'm assuming that spaces are not allowed in usernames given to the bot - if that's not the case, I can adjust the regex accordingly)