### PR TITLE
Program: For uploads, BES may not match both r.title and r.comment

### DIFF
--- a/src/CVNBot/Program.cs
+++ b/src/CVNBot/Program.cs
@@ -1188,14 +1188,16 @@ namespace CVNBot
                         attribs.Add("lmreason", ubes2.matchedReason);
                         uMsg = 95620;
                     }
-
-                    // Now check if the title matches BES
-                    ListMatch ubes1 = listman.MatchesList(r.title, 20);
-                    if (ubes1.Success)
+                    else
                     {
-                        attribs.Add("watchword", ubes1.matchedItem);
-                        attribs.Add("lmreason", ubes1.matchedReason);
-                        uMsg = 95620;
+                        // Now check if the title matches BES
+                        ListMatch ubes1 = listman.MatchesList(r.title, 20);
+                        if (ubes1.Success)
+                        {
+                            attribs.Add("watchword", ubes1.matchedItem);
+                            attribs.Add("lmreason", ubes1.matchedReason);
+                            uMsg = 95620;
+                        }
                     }
 
                     // Check if upload is watched


### PR DESCRIPTION
If we allow both of them to match, the code will end up trying
to add "watchword" twice, which is invalid. It can only exist once.

If the edit summary (r.comment) already matches BES, then skip
the title check. It would make no difference anyway, the outcome
is the same.

Fixes https://github.com/countervandalism/CVNBot/issues/59.