### PR TITLE
build: Support VS2019 and MSBuild 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Currently supported versions of Mono: **5.4**, **5.16**
 Once mono is installed, build the project. The below uses Debug, for local development. (See [Installation](./docs/install.md) for how to install it in production):
 
 ```bash
-countervandalism/CVNBot/src/CVNBot:$ msbuild src/CVNBot.sln /p:Configuration=Debug
+countervandalism/CVNBot:$ msbuild src/CVNBot.sln /p:Configuration=Debug
 ```
 
 Once built, you can run it:

--- a/src/CVNBot.exe.debug.config
+++ b/src/CVNBot.exe.debug.config
@@ -10,6 +10,9 @@
 	<configSections>
 		<section name="log4net" type="System.Configuration.IgnoreSectionHandler" />
 	</configSections>
+	<startup>
+		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+	</startup>
 	<log4net>
 		<appender name="ConsoleAppender" type="log4net.Appender.ConsoleAppender">
 			<layout type="log4net.Layout.PatternLayout" value="%date %-5level [%thread] %logger [%property{Nick}] %message%newline" />

--- a/src/CVNBot.exe.release.config
+++ b/src/CVNBot.exe.release.config
@@ -10,6 +10,9 @@
 	<configSections>
 		<section name="log4net" type="System.Configuration.IgnoreSectionHandler" />
 	</configSections>
+	<startup>
+		<supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+	</startup>
 	<log4net>
 		<appender name="ConsoleAppender" type="log4net.Appender.ConsoleAppender">
 			<layout type="log4net.Layout.PatternLayout" value="%date %-5level [%thread] %logger [%property{Nick}] %message%newline" />

--- a/src/CVNBot/CVNBot.csproj
+++ b/src/CVNBot/CVNBot.csproj
@@ -8,6 +8,10 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <!-- [Restore pre-2017 behaviour] No NuGetpackaging -->
     <IsPackable>false</IsPackable>
+    <!-- MSBuild 16+ overwrite our exe.config by default, which means
+         no more console or syslog logging. Keep MWBuild <= 15 behaviour.
+         https://github.com/nunit/nunit-console/pull/587 -->
+    <GenerateSupportedRuntime>false</GenerateSupportedRuntime>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'Default' ">
     <StartAction>Project</StartAction>
@@ -35,7 +39,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="..\Console.msgs">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="..\CVNBot-sample.ini">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -44,13 +48,13 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(Configuration)' == 'Debug' ">
     <Content Include="..\CVNBot.exe.debug.config">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <Link>CVNBot.exe.config</Link>
     </Content>
   </ItemGroup>
   <ItemGroup Condition=" '$(Configuration)' == 'Release' ">
     <Content Include="..\CVNBot.exe.release.config">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <Link>CVNBot.exe.config</Link>
     </Content>
   </ItemGroup>


### PR DESCRIPTION
The newer MSBuild has a new feature that automatically creates
a CVNBot.exe.config file in the bin/Release or bin/Debug directory
at the end of the build process:

> $ msbuild src/CVNBot.sln /p:Configuration=Debug
> …
> _CopyOutOfDateSourceItemsToOutputDirectory:
>   Copying "CVNBot-sample.ini" to "CVNBot/bin/Debug/CVNBot.ini".
>   Copying "CVNBot.exe.debug.config" to **"CVNBot/bin/Debug/CVNBot.exe.config"**.
>   …
> _CopyAppConfigFile:
>   Copying "CVNBot/obj/Debug/CVNBot.exe.withSupportedRuntime.config"
>   to **"CVNBot/bin/Debug/CVNBot.exe.config"**.

The last one is the problem. It overwrites our `CVNBot.exe.config`
file with a different file. Thus there is no more console log or
syslog appender.

Disable this new feature by setting <GenerateSupportedRuntime> to false.

Also, MSBuild16 recommends adding <startup> to all config files, which it
does by default in its override, so I'm adding that as well.