### PR TITLE
Multitarget .NET Core and mono

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,25 @@
 dist: bionic
+# https://docs.travis-ci.com/user/languages/csharp/
 language: csharp
-# Travis CI uses this repository:
-# http://download.mono-project.com/repo/ubuntu/dists/stable-bionic/snapshots/
-dotnet:
-  # - Visual Studio Community 2019 (VS 8.5) provides Mono 6.8.0 and MSBuild 16.5 (used by Krinkle)
-  #
-  # - Production (cvn.wmflabs.org) runs Debian 9 Stretch with Mono 6.8.0 and MSBuild 15.1
-  #   from <https://download.mono-project.com/repo/debian/dists/stable-stretch/snapshots/>.
-  #   See also https://github.com/countervandalism/infrastructure/blob/b33a9739e7/setup.yaml#L132
-  - '3.1'
-script:
-  - dotnet build src/CVNBot.sln -c Release
-  - dotnet build src/CVNBot.sln -c Debug
+jobs:
+  # Travis CI uses this repository for Mono releases:
+  # http://download.mono-project.com/repo/ubuntu/dists/stable-bionic/snapshots/
+  include:
+    # - Visual Studio Community 2019 (VS 8.5) provides Mono 6.8.0 and MSBuild 16.5 (used by Krinkle)
+    #
+    # - Production (cvn.wmflabs.org) runs Debian 9 Stretch with Mono 6.8.0 and MSBuild 15.1
+    #   from <https://download.mono-project.com/repo/debian/dists/stable-stretch/snapshots/>.
+    #   See also https://github.com/countervandalism/infrastructure/blob/b33a9739e7/setup.yaml#L132
+    - mono: '6.8.0'
+      script:
+        - msbuild src/CVNBot.sln /p:Configuration=Release
+        - msbuild src/CVNBot.sln /p:Configuration=Debug
+
+    - dotnet: '3.1'
+      mono: none
+      script:
+        - dotnet build src/CVNBot.sln -c Release
+        - dotnet build src/CVNBot.sln -c Debug
 notifications:
   irc:
     channels:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,16 @@ dist: bionic
 language: csharp
 # Travis CI uses this repository:
 # http://download.mono-project.com/repo/ubuntu/dists/stable-bionic/snapshots/
-mono:
+dotnet:
   # - Visual Studio Community 2019 (VS 8.5) provides Mono 6.8.0 and MSBuild 16.5 (used by Krinkle)
   #
   # - Production (cvn.wmflabs.org) runs Debian 9 Stretch with Mono 6.8.0 and MSBuild 15.1
   #   from <https://download.mono-project.com/repo/debian/dists/stable-stretch/snapshots/>.
   #   See also https://github.com/countervandalism/infrastructure/blob/b33a9739e7/setup.yaml#L132
-  - '6.8.0'
+  - '3.1'
 script:
-  - msbuild src/CVNBot.sln /p:Configuration=Release
-  - msbuild src/CVNBot.sln /p:Configuration=Debug
+  - dotnet build src/CVNBot.sln -c Release
+  - dotnet build src/CVNBot.sln -c Debug
 notifications:
   irc:
     channels:

--- a/src/CVNBot/CVNBot.csproj
+++ b/src/CVNBot/CVNBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" DefaultTargets="restore;Clean;Build">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;net472</TargetFrameworks>
     <PackageVersion>1.0.0.0</PackageVersion>
     <!-- [Restore pre-2017 behaviour] No NuGetpackaging -->
     <IsPackable>false</IsPackable>
@@ -30,6 +30,7 @@
       <HintPath>..\Mono.Data.Sqlite.dll</HintPath>
     </Reference>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Projects.xml">

--- a/src/CVNBot/CVNBot.csproj
+++ b/src/CVNBot/CVNBot.csproj
@@ -1,11 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" DefaultTargets="restore;Clean;Build">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
     <PackageVersion>1.0.0.0</PackageVersion>
-    <!-- [Restore pre-2017 behaviour]
-         Output to "bin/Release", not "bin/Release/:TargetFramework". s-->
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <!-- [Restore pre-2017 behaviour] No NuGetpackaging -->
     <IsPackable>false</IsPackable>
     <!-- MSBuild 16+ overwrite our exe.config by default, which means
@@ -32,10 +29,6 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Mono.Data.Sqlite.dll</HintPath>
     </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Web" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Projects.xml">

--- a/src/CVNBot/CVNBot.csproj
+++ b/src/CVNBot/CVNBot.csproj
@@ -29,6 +29,7 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Mono.Data.Sqlite.dll</HintPath>
     </Reference>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Projects.xml">

--- a/src/CVNBot/CVNBotUtils.cs
+++ b/src/CVNBot/CVNBotUtils.cs
@@ -1,10 +1,9 @@
 using System;
 using System.Collections;
-using System.Text;
-using System.Net;
 using System.IO;
+using System.Net;
+using System.Text;
 using System.Text.RegularExpressions;
-using System.Web;
 
 namespace CVNBot
 {
@@ -179,7 +178,7 @@ namespace CVNBot
         /// <returns></returns>
         public static string WikiEncode(string input)
         {
-            return HttpUtility.UrlEncode(input.Replace(' ', '_')).Replace("(","%28").Replace(")","%29").Replace("!","%21");
+            return WebUtility.UrlEncode(input.Replace(' ', '_')).Replace("(","%28").Replace(")","%29").Replace("!","%21");
         }
 
         /// <summary>


### PR DESCRIPTION
`netstandard` is more targeted at library authors that want to run on both platforms. Referencing `mscorlib` from `netstandard` isn't a particularly good idea, it's an implementation assembly of .NET Framework, although it is available as a typeforwarder in .NET Core. The common approach is to multitarget the project, which will build once for each target but that requires that the target framework is appended to the output path. This builds successfully without warnings.

Ref #68