### PR TITLE
Save built release as workflow artifact

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -52,6 +52,10 @@ jobs:
           msbuild /version
       - run: msbuild src/CVNBot.sln /p:Configuration=Release
       - run: msbuild src/CVNBot.sln /p:Configuration=Debug
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Release
+          path: src/CVNBot/bin/Release/
 
   macos:
     name: macOS


### PR DESCRIPTION
Hopefully this will mean I won't have to build the project manually again.